### PR TITLE
Revert "Remove temp file on non windows platforms"

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -232,12 +232,7 @@ int main(int argc, char **argv)
 //#if _DEBUG
 //						newfile=fopen(tmpbuf, "w+");
 //#else
-#ifdef WIN32
 						newfile=fopen(tmpbuf, "w+DT");
-#else
-						newfile=fopen(tmpbuf, "w+");
-						unlink(tmpbuf);
-#endif
 //#endif
 					}
 					if(mcpp_lib_main(foo.file, newfile, buf.name, buf.name, defMacro, includeDir)) {


### PR DESCRIPTION
Reverts roginvs/sslc#4

For some reasons causes segfauls on wasm build