### PR TITLE
Update Fallout RPU testing logic

### DIFF
--- a/test/test_on_fallout2_rpu_run.bash
+++ b/test/test_on_fallout2_rpu_run.bash
@@ -33,6 +33,7 @@ for f in $(find . -type f -iname '*.ssl') ; do
     FBASE=$(basename -s .ssl $f)
     FNAME=$(basename $f)
 
+    OLD_PWD=$(pwd)
     echo "======================= $DIR/$FNAME ========================"
     cd "$DIR"
 
@@ -58,37 +59,31 @@ for f in $(find . -type f -iname '*.ssl') ; do
     
     
 
-    echo " > expected return code $RETURN_CODE_EXPECTED, observed $RETURN_CODE_OBSERVED"
-
+   
     # if [ ! -f "$FBASE.int.expected" ]; then
     #   COMPILATION_FAILED_FILES="$COMPILATION_FAILED_FILES $DIR/$FNAME"
     # fi
 
-    if [ "$RETURN_CODE_EXPECTED" -ne 0 ]; then
-      COMPILATION_FAILED_FILES="$COMPILATION_FAILED_FILES $DIR/$FNAME"
-      if [ "$RETURN_CODE_EXPECTED" -ne "$RETURN_CODE_OBSERVED" ]; then
-        echo "=== Return code mismatch, want $RETURN_CODE_EXPECTED got $RETURN_CODE_OBSERVED ==="
+    if [ "$RETURN_CODE_OBSERVED" -ne "$RETURN_CODE_EXPECTED" ]; then
+        echo "  > FAIL: Return code mismatch, want $RETURN_CODE_EXPECTED got $RETURN_CODE_OBSERVED ==="
         TEST_FAILED_FILES="$TEST_FAILED_FILES $DIR/$FNAME=RETURNCODE"        
-      fi
-    elif [ "$RETURN_CODE_OBSERVED" -ne 0 ]; then
-        echo "=== Return code mismatch, want $RETURN_CODE_EXPECTED got $RETURN_CODE_OBSERVED ==="
-        TEST_FAILED_FILES="$TEST_FAILED_FILES $DIR/$FNAME=RETURNCODE"        
-    else # Both returned 0
+    else
+
       if ! diff -q $FBASE.stdout.expected $FBASE.stdout.observed ; then
-        echo "=== STDOUT mismatch ==="
+        echo "  > FAIL: STDOUT mismatch"
         set +e
         diff "$FBASE.stdout.expected" "$FBASE.stdout.observed"
         set -e
         TEST_FAILED_FILES="$TEST_FAILED_FILES $DIR/$FNAME=STDOUT"
       fi
 
-      if ! diff "$FBASE.int.expected" "$FBASE.int.observed" ; then
-        echo "=== .INT FILES DIFFERENT ==="
+      if [ "$RETURN_CODE_EXPECTED" -eq 0 ] && ! diff "$FBASE.int.expected" "$FBASE.int.observed" ; then
+        echo "  > FAIL: .INT files mismatch"
         TEST_FAILED_FILES="$TEST_FAILED_FILES $DIR/$FNAME=INT"
       fi
     fi
 
-    cd - >/dev/null 
+    cd "$OLD_PWD"
 done
 
 echo "=== Test results: ==="

--- a/test/test_on_fallout2_rpu_run.bash
+++ b/test/test_on_fallout2_rpu_run.bash
@@ -107,11 +107,6 @@ echo "=== Total tests: $((TESTS_SUCCESS_COUNT + TESTS_FAILED_COUNT)) ==="
 echo "=== Successful tests: $TESTS_SUCCESS_COUNT ==="
 echo "=== Failed tests: $TESTS_FAILED_COUNT ==="
 
-if [ "$TESTS_SUCCESS_COUNT" -eq 0 ]; then
-  echo "ERROR: No tests were run, please check the test files."
-  exit 1
-fi
-
 if [ "$EXPECTED_SUCCESSFULL_COMPILED_FILES" -eq 0 ]; then
   echo "ERROR: No files were expected to compile successfully, please check the setup."
   exit 1

--- a/test/test_on_fallout2_rpu_setup.bash
+++ b/test/test_on_fallout2_rpu_setup.bash
@@ -104,10 +104,12 @@ for f in $(find . -type f -iname '*.ssl') ; do
       set +e
 
       if [[ ! -n "$WINE_IS_INSTALLED" && -n "$WINE" ]]; then
-        echo "Installing wine"
-        sudo dpkg --add-architecture i386
-        sudo apt update
-        sudo apt install -y wine32
+        if ! which wine >/dev/null; then
+          echo "Installing wine"
+          sudo dpkg --add-architecture i386
+          sudo apt update
+          sudo apt install -y wine32
+        fi
         WINE_IS_INSTALLED="yes"
       fi
 


### PR DESCRIPTION
This should slightly simplify test checking logic. First, check returncodes. Next, if expected is successful code check the rest. Check `.int` first and then stdout.

Also this PR adds counters to show nice final statistics.