### PR TITLE
Remove emscripten daemon mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,13 +224,7 @@ jobs:
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-rpu-check')
         run: |
           export SSLC=../build/bin/compiler.mjs
-          echo "===starting daemon==="
-          (cd test && DAEMON=start $SSLC) &
-          sleep 3
-          echo "===done starting==="
-          export DAEMON=use
           (cd test && bash ./test_on_fallout2_rpu_run.bash)
-          (cd test && DAEMON=stop $SSLC)
 
       - name: Upload .wasm artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
In CI a daemon mode was used for emscripten build to increase build time from 101 minutes into ~10. For some reasons nodejs was waiting about 4 seconds after calling `process.exit()` for each compiler invocation so this was a workaround to avoid process spawning for all RPU files.

After changing compilation options this is not needed because it works pretty fast without it.